### PR TITLE
Added SQL queries for Netflix titles dataset analysis

### DIFF
--- a/Solution of 7 Problem.sql
+++ b/Solution of 7 Problem.sql
@@ -1,0 +1,40 @@
+-- 1. Count the total number of Movies and TV Shows
+SELECT type, COUNT(*) AS count
+FROM netflix_titles
+GROUP BY type;
+
+
+-- 2. Find the number of titles added in 2021
+SELECT COUNT(*) AS count
+FROM netflix_titles
+WHERE date_added LIKE '%2021';
+
+
+-- 3. List the top 5 countries with the most titles produced
+SELECT country, COUNT(*) AS title_count
+FROM netflix_titles
+GROUP BY country
+ORDER BY title_count DESC
+LIMIT 5;
+
+-- 4. Find the oldest TV show in the dataset
+SELECT title, release_year
+FROM netflix_titles
+WHERE type = 'TV Show'
+ORDER BY release_year ASC
+LIMIT 1;
+
+-- 5. Get the average duration of all movies
+SELECT AVG(CAST(REPLACE(duration, ' min', '') AS INT)) AS avg_duration
+FROM netflix_titles
+WHERE type = 'Movie';
+
+-- 6. Find all titles directed by 'Kirsten Johnson'
+SELECT title
+FROM netflix_titles
+WHERE director = 'Kirsten Johnson';
+
+-- 7. Find titles with a rating of 'TV-MA'
+SELECT title, rating
+FROM netflix_titles
+WHERE rating = 'TV-MA';


### PR DESCRIPTION
This file contains several SQL queries designed to analyze the Netflix titles dataset. The dataset includes information such as the title, director, cast, country, release year, rating, and genre. The following SQL queries were created to provide insights into the dataset:

Count the total number of Movies and TV Shows
A query that counts and groups titles based on their type (Movie or TV Show). Find the number of titles added in 2021
A query that filters titles based on their date_added to find those added in 2021. List the top 5 countries with the most titles produced A query to rank the countries by the number of titles produced, showing the top 5. Find the oldest TV show in the dataset
A query that retrieves the oldest TV show based on the release year. Get the average duration of all movies
A query that calculates the average runtime of all movies in minutes. Find all titles directed by 'Kirsten Johnson'
A query that lists all titles directed by Kirsten Johnson. Find titles with a rating of 'TV-MA'
A query that filters all titles with a TV-MA rating. These queries are useful for gaining insights into the composition and trends of Netflix content across different countries, genres, and time periods.